### PR TITLE
Nn fixes

### DIFF
--- a/main.go
+++ b/main.go
@@ -245,7 +245,7 @@ func (nn *neuralNet) train(x, y *mat.Dense) error {
 	}
 
 	// Define the output of the neural network.
-	output := mat.NewDense(0, 0, nil)
+	output := new(mat.Dense)
 
 	// Use backpropagation to adjust the weights and biases.
 	if err := nn.backpropagate(x, y, wHidden, bHidden, wOut, bOut, output); err != nil {
@@ -269,41 +269,41 @@ func (nn *neuralNet) backpropagate(x, y, wHidden, bHidden, wOut, bOut, output *m
 	for i := 0; i < nn.config.numEpochs; i++ {
 
 		// Complete the feed forward process.
-		hiddenLayerInput := mat.NewDense(0, 0, nil)
+		hiddenLayerInput := new(mat.Dense)
 		hiddenLayerInput.Mul(x, wHidden)
 		addBHidden := func(_, col int, v float64) float64 { return v + bHidden.At(0, col) }
 		hiddenLayerInput.Apply(addBHidden, hiddenLayerInput)
 
-		hiddenLayerActivations := mat.NewDense(0, 0, nil)
+		hiddenLayerActivations := new(mat.Dense)
 		applySigmoid := func(_, _ int, v float64) float64 { return sigmoid(v) }
 		hiddenLayerActivations.Apply(applySigmoid, hiddenLayerInput)
 
-		outputLayerInput := mat.NewDense(0, 0, nil)
+		outputLayerInput := new(mat.Dense)
 		outputLayerInput.Mul(hiddenLayerActivations, wOut)
 		addBOut := func(_, col int, v float64) float64 { return v + bOut.At(0, col) }
 		outputLayerInput.Apply(addBOut, outputLayerInput)
 		output.Apply(applySigmoid, outputLayerInput)
 
 		// Complete the backpropagation.
-		networkError := mat.NewDense(0, 0, nil)
+		networkError := new(mat.Dense)
 		networkError.Sub(y, output)
 
-		slopeOutputLayer := mat.NewDense(0, 0, nil)
+		slopeOutputLayer := new(mat.Dense)
 		applySigmoidPrime := func(_, _ int, v float64) float64 { return sigmoidPrime(v) }
 		slopeOutputLayer.Apply(applySigmoidPrime, output)
-		slopeHiddenLayer := mat.NewDense(0, 0, nil)
+		slopeHiddenLayer := new(mat.Dense)
 		slopeHiddenLayer.Apply(applySigmoidPrime, hiddenLayerActivations)
 
-		dOutput := mat.NewDense(0, 0, nil)
+		dOutput := new(mat.Dense)
 		dOutput.MulElem(networkError, slopeOutputLayer)
-		errorAtHiddenLayer := mat.NewDense(0, 0, nil)
+		errorAtHiddenLayer := new(mat.Dense)
 		errorAtHiddenLayer.Mul(dOutput, wOut.T())
 
-		dHiddenLayer := mat.NewDense(0, 0, nil)
+		dHiddenLayer := new(mat.Dense)
 		dHiddenLayer.MulElem(errorAtHiddenLayer, slopeHiddenLayer)
 
 		// Adjust the parameters.
-		wOutAdj := mat.NewDense(0, 0, nil)
+		wOutAdj := new(mat.Dense)
 		wOutAdj.Mul(hiddenLayerActivations.T(), dOutput)
 		wOutAdj.Scale(nn.config.learningRate, wOutAdj)
 		wOut.Add(wOut, wOutAdj)
@@ -315,7 +315,7 @@ func (nn *neuralNet) backpropagate(x, y, wHidden, bHidden, wOut, bOut, output *m
 		bOutAdj.Scale(nn.config.learningRate, bOutAdj)
 		bOut.Add(bOut, bOutAdj)
 
-		wHiddenAdj := mat.NewDense(0, 0, nil)
+		wHiddenAdj := new(mat.Dense)
 		wHiddenAdj.Mul(x.T(), dHiddenLayer)
 		wHiddenAdj.Scale(nn.config.learningRate, wHiddenAdj)
 		wHidden.Add(wHidden, wHiddenAdj)
@@ -345,19 +345,19 @@ func (nn *neuralNet) predict(x *mat.Dense) (*mat.Dense, error) {
 	}
 
 	// Define the output of the neural network.
-	output := mat.NewDense(0, 0, nil)
+	output := new(mat.Dense)
 
 	// Complete the feed forward process.
-	hiddenLayerInput := mat.NewDense(0, 0, nil)
+	hiddenLayerInput := new(mat.Dense)
 	hiddenLayerInput.Mul(x, nn.wHidden)
 	addBHidden := func(_, col int, v float64) float64 { return v + nn.bHidden.At(0, col) }
 	hiddenLayerInput.Apply(addBHidden, hiddenLayerInput)
 
-	hiddenLayerActivations := mat.NewDense(0, 0, nil)
+	hiddenLayerActivations := new(mat.Dense)
 	applySigmoid := func(_, _ int, v float64) float64 { return sigmoid(v) }
 	hiddenLayerActivations.Apply(applySigmoid, hiddenLayerInput)
 
-	outputLayerInput := mat.NewDense(0, 0, nil)
+	outputLayerInput := new(mat.Dense)
 	outputLayerInput.Mul(hiddenLayerActivations, nn.wOut)
 	addBOut := func(_, col int, v float64) float64 { return v + nn.bOut.At(0, col) }
 	outputLayerInput.Apply(addBOut, outputLayerInput)

--- a/main.go
+++ b/main.go
@@ -223,10 +223,15 @@ func (nn *neuralNet) train(x, y *mat.Dense) error {
 	randSource := rand.NewSource(time.Now().UnixNano())
 	randGen := rand.New(randSource)
 
-	wHiddenRaw := make([]float64, nn.config.hiddenNeurons*nn.config.inputNeurons)
-	bHiddenRaw := make([]float64, nn.config.hiddenNeurons)
-	wOutRaw := make([]float64, nn.config.outputNeurons*nn.config.hiddenNeurons)
-	bOutRaw := make([]float64, nn.config.outputNeurons)
+	wHidden := mat.NewDense(nn.config.inputNeurons, nn.config.hiddenNeurons, nil)
+	bHidden := mat.NewDense(1, nn.config.hiddenNeurons, nil)
+	wOut := mat.NewDense(nn.config.hiddenNeurons, nn.config.outputNeurons, nil)
+	bOut := mat.NewDense(1, nn.config.outputNeurons, nil)
+
+	wHiddenRaw := wHidden.RawMatrix().Data
+	bHiddenRaw := bHidden.RawMatrix().Data
+	wOutRaw := wOut.RawMatrix().Data
+	bOutRaw := bOut.RawMatrix().Data
 
 	for _, param := range [][]float64{
 		wHiddenRaw,
@@ -238,11 +243,6 @@ func (nn *neuralNet) train(x, y *mat.Dense) error {
 			param[i] = randGen.Float64()
 		}
 	}
-
-	wHidden := mat.NewDense(nn.config.inputNeurons, nn.config.hiddenNeurons, wHiddenRaw)
-	bHidden := mat.NewDense(1, nn.config.hiddenNeurons, bHiddenRaw)
-	wOut := mat.NewDense(nn.config.hiddenNeurons, nn.config.outputNeurons, wOutRaw)
-	bOut := mat.NewDense(1, nn.config.outputNeurons, bOutRaw)
 
 	// Define the output of the neural network.
 	output := mat.NewDense(0, 0, nil)


### PR DESCRIPTION
- use `RawMatrix().Data` to get at the underlying data slice
- use the more idiomatic `new(mat.Dense)` to create (pointer to) default value `mat.Dense` matrices